### PR TITLE
Use init_scope in SequentialFeatureExtractor

### DIFF
--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -10,8 +10,8 @@ class SequentialFeatureExtractor(chainer.Chain):
     Callable objects, such as :class:`chainer.Link` and
     :class:`chainer.Function`, can be registered to this chain with
     :meth:`init_scope`.
-    This link keeps the order of registerations and :meth:__call__
-    executes callables in the order in which they are registered to.
+    This chain keeps the order of registerations and :meth:`__call__`
+    executes callables in that order.
     A :class:`chainer.Link` object in the sequence will be added as
     a child link of this link.
 

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -1,5 +1,3 @@
-import collections
-
 import chainer
 
 

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -124,8 +124,7 @@ class SequentialFeatureExtractor(chainer.Chain):
                 features[name] = h
 
         if self._return_tuple:
-            features = tuple(
-                [features[name] for name in layer_names])
+            features = tuple(features[name] for name in layer_names)
         else:
             features = list(features.values())[0]
         return features

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -38,13 +38,12 @@ class SequentialFeatureExtractor(chainer.Chain):
         >>>     model.l2 = L.Linear(None, 1000)
         >>>     model.l2_relu = F.relu
         >>>     model.l3 = L.Linear(None, 10)
+        >>> # This is the output of layer l3.
+        >>> feat3 = model(x)
+        >>> # The layers to be collected can be changed.
         >>> model.layer_names = ('l2_relu', 'l1_relu')
         >>> # These are outputs of layer l2_relu and l1_relu.
-        >>> feat1, feat2 = model(x)
-        >>> # The layer_names can be dynamically changed.
-        >>> model.layer_names = 'l3'
-        >>> # This is an output of layer l1.
-        >>> feat3 = model(x)
+        >>> feat2, feat1 = model(x)
 
     Params:
         layer_names (string or iterable of strings):

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -7,13 +7,13 @@ class SequentialFeatureExtractor(chainer.Chain):
 
     This class is a base class that can be used for an implementation of
     a feature extractor model.
-    Callabel objects, such as :class:`chainer.Link` and
-    :class:`chainer.Function`, can be registered to this link with
+    Callable objects, such as :class:`chainer.Link` and
+    :class:`chainer.Function`, can be registered to this chain with
     :meth:`init_scope`.
-    This link keeps the order of registerations and conducts the computation
-    in the same order when :meth:`__call__` is called.
+    This link keeps the order of registerations and :meth:__call__
+    executes callables in the order in which they are registered to.
     A :class:`chainer.Link` object in the sequence will be added as
-    a child link of this object.
+    a child link of this link.
 
     :meth:`__call__` returns single or multiple features that are picked up
     through a stream of computation.

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -94,7 +94,7 @@ class SequentialFeatureExtractor(chainer.Chain):
             raise ValueError('Invalid layer name')
 
         self._return_tuple = return_tuple
-        self._layer_names = layer_names
+        self._layer_names = tuple(layer_names)
 
     def __call__(self, x):
         """Forward this model.

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -38,7 +38,7 @@ class SequentialFeatureExtractor(chainer.Chain):
         >>>     model.l2 = L.Linear(None, 1000)
         >>>     model.l2_relu = F.relu
         >>>     model.l3 = L.Linear(None, 10)
-        >>> model.layer_names = ['l2_relu', 'l1_relu']
+        >>> model.layer_names = ('l2_relu', 'l1_relu')
         >>> # These are outputs of layer l2_relu and l1_relu.
         >>> feat1, feat2 = model(x)
         >>> # The layer_names can be dynamically changed.
@@ -89,7 +89,7 @@ class SequentialFeatureExtractor(chainer.Chain):
             return_tuple = True
         else:
             return_tuple = False
-            layer_names = [layer_names]
+            layer_names = (layer_names,)
         if any(name not in self._order for name in layer_names):
             raise ValueError('Invalid layer name')
 
@@ -108,7 +108,7 @@ class SequentialFeatureExtractor(chainer.Chain):
 
         """
         if self._layer_names is None:
-            layer_names = [self._order[-1]]
+            layer_names = (self._order[-1],)
         else:
             layer_names = self._layer_names
 

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -9,11 +9,11 @@ class SequentialFeatureExtractor(chainer.Chain):
 
     This class is a base class that can be used for an implementation of
     a feature extractor model.
-    The link takes an argument :obj:`layers` that specifies the computation
-    conducted in :meth:`__call__`.
-    :obj:`layers` is a :class:`collections.OrderedDict` of
-    callable objects called layers, which are going to be called sequentially
-    starting from the top to the bottom.
+    Callabel objects, such as :class:`chainer.Link` and
+    :class:`chainer.Function`, can be registered to this link with
+    :meth:`init_scope`.
+    This link keeps the order of registerations and conducts the computation
+    in the same order when :meth:`__call__` is called.
     A :class:`chainer.Link` object in the sequence will be added as
     a child link of this object.
 
@@ -33,13 +33,14 @@ class SequentialFeatureExtractor(chainer.Chain):
         >>> import collections
         >>> import chainer.functions as F
         >>> import chainer.links as L
-        >>> layers = collections.OrderedDict([
-        >>>     ('l1', L.Linear(None, 1000)),
-        >>>     ('l1_relu', F.relu),
-        >>>     ('l2', L.Linear(None, 1000)),
-        >>>     ('l2_relu', F.relu),
-        >>>     ('l3', L.Linear(None, 10))])
-        >>> model = SequentialFeatureExtractor(layers, ['l2_relu', 'l1_relu'])
+        >>> model = SequentialFeatureExtractor()
+        >>> with model.init_scope():
+        >>>     model.l1 = L.Linear(None, 1000)
+        >>>     model.l1_relu = F.relu
+        >>>     model.l2 = L.Linear(None, 1000)
+        >>>     model.l2_relu = F.relu
+        >>>     model.l3 = L.Linear(None, 10)
+        >>> model.layer_names = ['l2_relu', 'l1_relu']
         >>> # These are outputs of layer l2_relu and l1_relu.
         >>> feat1, feat2 = model(x)
         >>> # The layer_names can be dynamically changed.
@@ -47,9 +48,7 @@ class SequentialFeatureExtractor(chainer.Chain):
         >>> # This is an output of layer l1.
         >>> feat3 = model(x)
 
-    Args:
-        layers (collections.OrderedDict of callables):
-            Callable objects called in the forward pass.
+    Params:
         layer_names (string or iterable of strings):
             Names of layers whose outputs will be collected in
             the forward pass.

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -64,6 +64,9 @@ class SequentialFeatureExtractor(chainer.Chain):
             self._order.append(name)
 
     def __delattr__(self, name):
+        if self._layer_names and name in self._layer_names:
+            raise AttributeError(
+                'Layer {:s} is registered to layer_names.'.format(name))
         super(SequentialFeatureExtractor, self).__delattr__(name)
         try:
             self._order.remove(name)

--- a/tests/links_tests/model_tests/test_sequential_feature_extractor.py
+++ b/tests/links_tests/model_tests/test_sequential_feature_extractor.py
@@ -28,13 +28,13 @@ class TestSequentialFeatureExtractorOrderedDictFunctions(unittest.TestCase):
         self.f2 = DummyFunc()
         self.l2 = ConstantStubLink(np.random.uniform(size=(1, 3, 24, 24)))
 
-        self.link = SequentialFeatureExtractor(
-            collections.OrderedDict(
-                [('l1', self.l1),
-                 ('f1', self.f1),
-                 ('f2', self.f2),
-                 ('l2', self.l2)]),
-            layer_names=['l1', 'f1', 'f2'])
+        self.link = SequentialFeatureExtractor()
+        with self.link.init_scope():
+            self.link.l1 = self.l1
+            self.link.f1 = self.f1
+            self.link.f2 = self.f2
+            self.link.l2 = self.l2
+        self.link.layer_names = ['l1', 'f1', 'f2']
         self.x = np.random.uniform(size=(1, 3, 24, 24))
 
     def check_call_output(self):
@@ -81,36 +81,6 @@ class TestSequentialFeatureExtractorOrderedDictFunctions(unittest.TestCase):
     @attr.gpu
     def test_call_dynamic_layer_names_gpu(self):
         self.check_call_dynamic_layer_names()
-
-
-class TestSequentialFeatureExtractorCopy(unittest.TestCase):
-
-    def setUp(self):
-        self.l1 = ConstantStubLink(np.random.uniform(size=(1, 3, 24, 24)))
-        self.f1 = DummyFunc()
-        self.f2 = DummyFunc()
-        self.l2 = ConstantStubLink(np.random.uniform(size=(1, 3, 24, 24)))
-
-        self.link = SequentialFeatureExtractor(
-            collections.OrderedDict(
-                [('l1', self.l1),
-                 ('f1', self.f1),
-                 ('f2', self.f2),
-                 ('l2', self.l2)]),
-            layer_names=['l1', 'f1', 'f2', 'l2'])
-
-    def check_copy(self):
-        copied = self.link.copy()
-        self.assertIs(copied.l1, copied.layers['l1'])
-        self.assertIs(copied.l2, copied.layers['l2'])
-
-    def test_copy_cpu(self):
-        self.check_copy()
-
-    @attr.gpu
-    def test_copy_gpu(self):
-        self.link.to_gpu()
-        self.check_copy()
 
 
 testing.run_module(__name__, __file__)

--- a/tests/links_tests/model_tests/test_sequential_feature_extractor.py
+++ b/tests/links_tests/model_tests/test_sequential_feature_extractor.py
@@ -1,4 +1,3 @@
-import collections
 import unittest
 
 import numpy as np

--- a/tests/links_tests/model_tests/test_sequential_feature_extractor.py
+++ b/tests/links_tests/model_tests/test_sequential_feature_extractor.py
@@ -59,9 +59,9 @@ class TestSequentialFeatureExtractor(unittest.TestCase):
 
         for out, layer_name in zip(outs, layer_names):
             self.assertIsInstance(out, chainer.Variable)
-            out = to_cpu(out.data)
+            self.assertIsInstance(out.data, self.link.xp.ndarray)
 
-            self.assertIsInstance(out, self.link.xp.ndarray)
+            out = to_cpu(out.data)
             np.testing.assert_equal(out, to_cpu(expects[layer_name].data))
 
     def check_basic(self):


### PR DESCRIPTION
`OrderedDict` is similar to `**links` of `chainer.Chain.__init__`. This style is not recommended since Chainer v2.